### PR TITLE
Create linalgwrap version information automatically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,8 @@ project(linalgwrap VERSION 0.1.0)
 drb_setup_project(linalgwrap)
 
 # Global include directories for this project:
-include_directories("${linalgwrap_SOURCE_DIR}/src")
+include_directories("${linalgwrap_SOURCE_DIR}/src")  # for default sources
+include_directories("${linalgwrap_BINARY_DIR}/src")  # for generated sources
 
 # enable testing of this project
 enable_testing()

--- a/cmake/install_modules_packages.cmake
+++ b/cmake/install_modules_packages.cmake
@@ -24,7 +24,7 @@
 #
 # Requires the variable PackageModuleLocation to be set.
 
-# Installing DebugReleaseBuild cmake module
+# Installing cmake modules
 install(DIRECTORY "${linalgwrap_SOURCE_DIR}/cmake/modules"
 	DESTINATION ${PackageModuleLocation}
 	COMPONENT devel

--- a/cmake/modules/WriteVersionHeader.cmake
+++ b/cmake/modules/WriteVersionHeader.cmake
@@ -1,0 +1,62 @@
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2016 by the linalgwrap authors
+##
+## This file is part of linalgwrap.
+##
+## linalgwrap is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published
+## by the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## linalgwrap is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with linalgwrap. If not, see <http://www.gnu.org/licenses/>.
+##
+## ---------------------------------------------------------------------
+
+include(CMakeParseArguments)
+
+function(WRITE_VERSION_HEADER _filename)
+	# Write a header file which defines the macro contstants
+	# VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH according
+	# to the current project version or a version supplied
+	# via the VERSION flag.
+
+
+	set(options )
+	set(oneValueArgs VERSION)
+	set(multiValueArgs )
+
+	cmake_parse_arguments(WVH "${options}" "${oneValueArgs}" "${multiValueArgs}"  ${ARGN})
+
+	if(WVH_UNPARSED_ARGUMENTS)
+		message(FATAL_ERROR "Unknown keywords given to WRITE_VERSION_HEADER: \"${WVH_UNPARSED_ARGUMENTS}\"")
+	endif()
+
+	if("${WVH_VERSION}" STREQUAL "")
+		if ("${PROJECT_VERSION}" STREQUAL "")
+			message(FATAL_ERROR "No VERSION specified for WRITE_VERSION_HEADER()")
+		else()
+			set(WVH_VERSION "${PROJECT_VERSION}")
+		endif()
+	endif()
+
+	# Split version into individual vars:
+	string(REPLACE "." ";" VERSION_LIST ${WVH_VERSION})
+	list(GET VERSION_LIST 0 WVH_MAJOR)
+	list(GET VERSION_LIST 1 WVH_MINOR)
+	list(GET VERSION_LIST 2 WVH_PATCH)
+
+	# Now dump the header:
+
+	file(WRITE "${_filename}"
+"#pragma once
+#define VERSION_MAJOR ${WVH_MAJOR}
+#define VERSION_MINOR ${WVH_MINOR}
+#define VERSION_PATCH ${WVH_PATCH}")
+endfunction()

--- a/examples/diagonal/diagonal.cc
+++ b/examples/diagonal/diagonal.cc
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <linalgwrap/LazyMatrixWrapper.hh>
 #include <linalgwrap/SmallMatrix.hh>
+#include <linalgwrap/version.hh>
 #include <linalgwrap/view.hh>
 
 using namespace linalgwrap;
@@ -41,6 +42,15 @@ int main() {
     // Define some types
     typedef double scalar_type;
     typedef SmallMatrix<scalar_type> stored_matrix_type;
+
+    //
+    // -------------------------
+    //
+
+    // Print the linalgwrap version we run on:
+    std::cout << "Running with linalgwrap " << version::version_string()
+              << std::endl
+              << std::endl;
 
     //
     // -------------------------

--- a/src/linalgwrap/CMakeLists.txt
+++ b/src/linalgwrap/CMakeLists.txt
@@ -29,6 +29,10 @@ set(LINALGWRAP_SOURCES
 	version.cc
 )	
 
+# Dump the current version as an include file.
+include(WriteVersionHeader)
+WRITE_VERSION_HEADER("${CMAKE_CURRENT_BINARY_DIR}/version_defs.hh")
+
 # add the libraries for Debug and Release:
 drb_add_library(linalgwrap
 	DBGSUFFIX  ".g"
@@ -63,6 +67,10 @@ install(DIRECTORY .
 	DESTINATION "include/linalgwrap"
 	COMPONENT devel
 	FILES_MATCHING PATTERN "*.hh"
+)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/version_defs.hh"
+	DESTINATION "include/linalgwrap"
+	COMPONENT devel
 )
 
 # Export the target specifications for linalgwrap.

--- a/src/linalgwrap/version.cc
+++ b/src/linalgwrap/version.cc
@@ -20,8 +20,12 @@
 #include "linalgwrap/version.hh"
 #include <sstream>
 
+namespace linalgwrap {
+
 std::string version::version_string() {
     std::stringstream ss;
-    ss << major << "." << minor << "." << revision;
+    ss << major << "." << minor << "." << patch;
     return ss.str();
 }
+
+}  // namespace linalgwrap

--- a/src/linalgwrap/version.hh
+++ b/src/linalgwrap/version.hh
@@ -18,17 +18,22 @@
 //
 
 #pragma once
+#include "linalgwrap/version_defs.hh"  // will be created by cmake
 #include <string>
 
-#define VERSION_MAJOR 0
-#define VERSION_MINOR 1
-#define VERSION_REVISION 0
+// The file linalgwrap/version_defs.hh will be created by cmake from
+// the interal project version and will contain definitions of the
+// macros VERSION_MINOR VERSION_MAJOR VERSION_PATCH
+
+namespace linalgwrap {
 
 struct version {
     static int constexpr major{VERSION_MAJOR};
     static int constexpr minor{VERSION_MINOR};
-    static int constexpr revision{VERSION_REVISION};
+    static int constexpr patch{VERSION_PATCH};
 
     // Return the version as a string
     static std::string version_string();
 };
+
+}  // namespace linalgwrap


### PR DESCRIPTION
The version information available from ``linalgwrap/version.hh`` is now created
automatically by ``cmake`` from the provided project version, so version
numbers only have to be provided once in ``CMakeLists.txt``.