### PR TITLE
Basic IO functionality for formatted matrix printing

### DIFF
--- a/src/linalgwrap/BlockDiagonalMatrix.hh
+++ b/src/linalgwrap/BlockDiagonalMatrix.hh
@@ -25,6 +25,9 @@
 
 namespace linalgwrap {
 
+// TODO consider specialising this class for 2 and 3 matrices.
+//      Lambdas are terribly slow and could be avoided ...
+
 // Forward definition of base class:
 template <typename... Matrices>
 class BlockDiagonalMatrixBase;
@@ -106,9 +109,11 @@ template <typename... Matrices>
 BlockDiagonalMatrix<Matrices...>::BlockDiagonalMatrix(
       std::tuple<Matrices...> blocks)
       : m_blocks{std::move(blocks)}, m_size{0} {
+#ifdef DEBUG
     // Assert that all matrix blocks are quadratic.
     tuple_for_each([](auto& mat) { assert_size(mat.n_rows(), mat.n_cols()); },
                    tuple_ref(m_blocks));
+#endif
 
     // Determine size of this matrix:
     // Lambda to add size of current block in:

--- a/src/linalgwrap/CMakeLists.txt
+++ b/src/linalgwrap/CMakeLists.txt
@@ -27,6 +27,7 @@ set(LINALGWRAP_SOURCES
 	ExceptionBase.cc
 	ExceptionSystem.cc
 	version.cc
+	io/Mathematica.cc
 )	
 
 # Dump the current version as an include file.

--- a/src/linalgwrap/io.hh
+++ b/src/linalgwrap/io.hh
@@ -1,0 +1,26 @@
+//
+// Copyright (C) 2016 by the linalgwrap authors
+//
+// This file is part of linalgwrap.
+//
+// linalgwrap is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// linalgwrap is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with linalgwrap. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+#include "linalgwrap/io/DataWriter_i.hh"
+#include "linalgwrap/io/FileTypeWriter.hh"
+#include "linalgwrap/io/FileType_i.hh"
+#include "linalgwrap/io/Mathematica.hh"
+#include "linalgwrap/io/MatrixPrinter.hh"
+#include "linalgwrap/io/OstreamState.hh"

--- a/src/linalgwrap/io/DataWriter_i.hh
+++ b/src/linalgwrap/io/DataWriter_i.hh
@@ -1,0 +1,87 @@
+//
+// Copyright (C) 2016 by the linalgwrap authors
+//
+// This file is part of linalgwrap.
+//
+// linalgwrap is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// linalgwrap is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with linalgwrap. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+#include <linalgwrap/Matrix_i.hh>
+#include <linalgwrap/Subscribable.hh>
+
+namespace linalgwrap {
+namespace io {
+
+// TODO we need something hierachical like
+//      writer.iteration("1").write("ekin", 2.4);
+//      also: printlevel!
+//
+//      The levels below should be of the same writer type
+//      (Tree structure)
+//
+//      if the write operations are implemented out of place, we
+//      save the templating in Scalar!
+
+/** Generic interface class to write data to a stream or file under in some
+ *  kind of data format. The details are specified by the implementing
+ *  classes
+ *
+ * \tparam Scalar   The scalar type to use for all data.
+ */
+template <typename Scalar>
+class DataWriter_i : public Subscribable {
+  public:
+    /** Write a labelled matrix to the ostream under the format represented by
+     * this class.
+     *  Use the provided label string to indicate the matrix
+     *
+     * \return Is the writer still in a good state?
+     *  */
+    virtual bool write(const std::string& label,
+                       const Matrix_i<Scalar>& mat) = 0;
+
+    /** Write a non-labelled matrix to the stream repersented by this class
+     * under the format represented by this class
+     *
+     * \return Is the writer still in a good state?
+     * */
+    virtual bool write(const Matrix_i<Scalar>& mat) = 0;
+
+    /** Write a comment string
+     *
+     * \return Is the writer still in a good state?
+     * **/
+    virtual bool write_comment(const std::string&) = 0;
+
+    /** Write an empty line
+     *
+     * \return Is the writer still in a good state?
+     * */
+    virtual bool write_empty_line() = 0;
+
+    /** Write a string verbatim as it is.
+     *
+     * \return Is the writer still in a good state?
+     * */
+    virtual bool write_verbatim(const std::string& s) = 0;
+
+    /** Is the writer still in a good state? */
+    virtual bool good() const = 0;
+
+    operator bool() const { return good(); }
+};
+
+}  // namespace io
+}  // namespace linalgwrap

--- a/src/linalgwrap/io/FileTypeWriter.hh
+++ b/src/linalgwrap/io/FileTypeWriter.hh
@@ -1,0 +1,140 @@
+//
+// Copyright (C) 2016 by the linalgwrap authors
+//
+// This file is part of linalgwrap.
+//
+// linalgwrap is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// linalgwrap is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with linalgwrap. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+#include "DataWriter_i.hh"
+#include "FileType_i.hh"
+#include <type_traits>
+
+namespace linalgwrap {
+namespace io {
+
+/** \brief Write data to a std::ostream in a well-defined format.
+ *
+ * \tparam Scalar   The scalar type to use for all data.
+ * \tparam FileType The file type to use for the formatting of the
+ *                  data.
+ */
+template <typename FileType, typename Scalar>
+class FileTypeWriter : public DataWriter_i<Scalar> {
+    static_assert(std::is_base_of<FileType_i, FileType>::value,
+                  "FileType must be a child of FileType_i.");
+
+  public:
+    typedef FileType file_type;
+
+    /** Construct a formatted stream writer from an output stream and a
+     *  filetype object. */
+    FileTypeWriter(std::ostream& out, const file_type ft);
+
+    /** Write a labelled matrix to the ostream under the format represented by
+     * this class.
+     *  Use the provided label string to indicate the matrix */
+    bool write(const std::string& label, const Matrix_i<Scalar>& mat) override;
+
+    /** Write a non-labelled matrix to the stream repersented by this class
+     * under the format represented by this class */
+    bool write(const Matrix_i<Scalar>& mat) override;
+
+    /** Write a comment string **/
+    bool write_comment(const std::string&) override;
+
+    /** Write an empty line */
+    bool write_empty_line() override;
+
+    /** Write a string verbatim as it is. */
+    bool write_verbatim(const std::string& s) override;
+
+    /** Is the writer still in a good state? */
+    bool good() const override;
+
+  private:
+    std::ostream& m_out;
+    const file_type m_ft;
+};
+
+/** Convenience function to make a FormattedStreamWriter object by
+ * constructing the FileType in-place */
+template <typename FileType, typename Scalar, typename... GArgs>
+FileTypeWriter<FileType, Scalar> make_writer(std::ostream& out,
+                                             GArgs&&... gargs);
+
+//
+// ------------------------------------------------------------------------
+//
+
+template <typename FileType, typename Scalar>
+inline FileTypeWriter<FileType, Scalar>::FileTypeWriter(std::ostream& out,
+                                                        const file_type ft)
+      : m_out{out}, m_ft{std::forward<const file_type>(ft)} {
+    assert_throw(m_out, ExcIO());
+}
+
+template <typename FileType, typename Scalar>
+inline bool FileTypeWriter<FileType, Scalar>::write(
+      const std::string& label, const Matrix_i<Scalar>& mat) {
+    assert_throw(m_out, ExcIO());
+    m_ft.write(m_out, label, mat);
+    return m_out.good();
+}
+
+template <typename FileType, typename Scalar>
+inline bool FileTypeWriter<FileType, Scalar>::write(
+      const Matrix_i<Scalar>& mat) {
+    assert_throw(m_out, ExcIO());
+    m_ft.write(m_out, mat);
+    return m_out.good();
+}
+
+template <typename FileType, typename Scalar>
+inline bool FileTypeWriter<FileType, Scalar>::write_comment(
+      const std::string& comment) {
+    assert_throw(m_out, ExcIO());
+    m_ft.write_comment(m_out, comment);
+    return m_out.good();
+}
+
+template <typename FileType, typename Scalar>
+inline bool FileTypeWriter<FileType, Scalar>::write_empty_line() {
+    assert_throw(m_out, ExcIO());
+    m_out << std::endl;
+    return m_out.good();
+}
+
+template <typename FileType, typename Scalar>
+inline bool FileTypeWriter<FileType, Scalar>::write_verbatim(
+      const std::string& s) {
+    assert_throw(m_out, ExcIO());
+    m_out << s;
+    return m_out.good();
+}
+
+template <typename FileType, typename Scalar>
+inline bool FileTypeWriter<FileType, Scalar>::good() const {
+    return m_out.good();
+}
+
+template <typename FileType, typename Scalar, typename... GArgs>
+FileTypeWriter<FileType, Scalar> make_formatted_stream_writer(
+      std::ostream& out, GArgs&&... gargs) {
+    return FileTypeWriter<FileType, Scalar>{out, FileType{gargs...}};
+}
+
+}  // namespace io
+}  // namespace linalgwrap

--- a/src/linalgwrap/io/FileType_i.hh
+++ b/src/linalgwrap/io/FileType_i.hh
@@ -1,0 +1,66 @@
+//
+// Copyright (C) 2016 by the linalgwrap authors
+//
+// This file is part of linalgwrap.
+//
+// linalgwrap is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// linalgwrap is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with linalgwrap. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+#include "linalgwrap/Exceptions.hh"
+#include "linalgwrap/Matrix_i.hh"
+#include <ostream>
+#include <string>
+
+namespace linalgwrap {
+namespace io {
+
+/** \brief Marker interface to inherit all file type classes from
+ *
+ * All classes inheriting from this class should provide proper implementations
+ * of the methods we define here and furthermore the following static
+ * attributes:
+ *
+ * - static const std::vector<std::string> extensions
+ *   A list of extensions, which is commonly used with this file type.
+ *   the first element at index 0 should be the default extension to add when
+ *   writing such a file.
+ *
+ * Specialisations for writing some kinds of matrices specially (like complex
+ * or sparse matrices) can also be provided when implementing this class.
+ * */
+class FileType_i {
+  public:
+    /** Write a labelled matrix to the ostream under the format represented by
+     * this class.
+     *  Use the provided label string to indicate the matrix */
+    template <typename Scalar>
+    void write(std::ostream&, const std::string&,
+               const Matrix_i<Scalar>&) const {
+        assert_dbg(false, ExcNotImplemented());
+    }
+
+    /** Write a non-labelled matrix to the ostream under the format represented
+     * by this class. */
+    template <typename Scalar>
+    void write(std::ostream&, const Matrix_i<Scalar>&) const {
+        assert_dbg(false, ExcNotImplemented());
+    }
+
+    /** Write a comment string **/
+    virtual void write_comment(std::ostream&, const std::string&) const = 0;
+};
+
+}  // namespace io
+}  // namespace linalgwrap

--- a/src/linalgwrap/io/Mathematica.cc
+++ b/src/linalgwrap/io/Mathematica.cc
@@ -22,10 +22,10 @@
 namespace linalgwrap {
 namespace io {
 
-Mathematica::Mathematica() : m_thresh{1e-16}, m_check_for_thresh{false} {};
+Mathematica::Mathematica() : m_thresh{1e-16}, m_check_for_thresh{false} {}
 
 Mathematica::Mathematica(double thresh)
-      : m_thresh{thresh}, m_check_for_thresh{true} {};
+      : m_thresh{thresh}, m_check_for_thresh{true} {}
 
 const std::vector<std::string> Mathematica::extensions{"m"};
 

--- a/src/linalgwrap/io/Mathematica.cc
+++ b/src/linalgwrap/io/Mathematica.cc
@@ -1,0 +1,33 @@
+//
+// Copyright (C) 2016 by the linalgwrap authors
+//
+// This file is part of linalgwrap.
+//
+// linalgwrap is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// linalgwrap is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with linalgwrap. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "Mathematica.hh"
+
+namespace linalgwrap {
+namespace io {
+
+Mathematica::Mathematica() : m_thresh{1e-16}, m_check_for_thresh{false} {};
+
+Mathematica::Mathematica(double thresh)
+      : m_thresh{thresh}, m_check_for_thresh{true} {};
+
+const std::vector<std::string> Mathematica::extensions{"m"};
+
+}  // namespace io
+}  // namespace linalgwrap

--- a/src/linalgwrap/io/Mathematica.hh
+++ b/src/linalgwrap/io/Mathematica.hh
@@ -1,0 +1,116 @@
+//
+// Copyright (C) 2016 by the linalgwrap authors
+//
+// This file is part of linalgwrap.
+//
+// linalgwrap is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// linalgwrap is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with linalgwrap. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+#include "FileType_i.hh"
+#include <vector>
+
+namespace linalgwrap {
+namespace io {
+
+class Mathematica : public FileType_i {
+  public:
+    /** Construct a Mathematica file type. */
+    Mathematica();
+
+    /** Construct a Mathematica file type, which drops elements less than
+     *  a given threshold */
+    Mathematica(double thresh);
+
+    /** \brief Write a matrix to a stream in mathematica format.
+     *
+     * The matrix ends up being written as a Mathematica list, which can be
+     * used under the label provided. Note, that mathematica does not allow
+     * certain characters in the label, so be careful.
+     */
+    template <typename Matrix>
+    void write(std::ostream& out, const std::string& label,
+               const Matrix& mat) const;
+
+    /** \brief Write a matrix to a stream in mathematica format.
+     *
+     * The matrix ends up beeing written as a 2D Mathematica list.
+     */
+    template <typename Scalar>
+    void write(std::ostream& out, const Matrix_i<Scalar>& mat) const;
+
+    /** Write a comment **/
+    void write_comment(std::ostream&, const std::string&) const override;
+
+    /** Extensions Mathematica files typically use */
+    static const std::vector<std::string> extensions;
+
+  private:
+    template <typename Scalar>
+    void write_elem(std::ostream& out, Scalar value) const;
+
+    //! Threshold below which elements are considered zero.
+    double m_thresh;
+
+    //! Should we check for value being less then eps before writing it?
+    bool m_check_for_thresh;
+};
+
+//
+// ---------------------------------------
+//
+
+template <typename Matrix>
+void Mathematica::write(std::ostream& out, const std::string& label,
+                        const Matrix& mat) const {
+    assert_throw(out, ExcIO());
+    out << label << " = ";
+    write(out, mat);
+}
+
+template <typename Scalar>
+void Mathematica::write(std::ostream& out, const Matrix_i<Scalar>& mat) const {
+    assert_throw(out, ExcIO());
+    if (mat.n_rows() == 0 || mat.n_cols() == 0) return;
+
+    out << "{";
+    for (auto row : range(mat.n_rows())) {
+        if (row != 0) out << "," << std::endl;
+        out << "{";
+        for (auto col : range(mat.n_cols())) {
+            if (col != 0) out << ",";
+            write_elem(out, mat(row, col));
+        }
+        out << "}";
+    }
+    out << "};" << std::endl;
+}
+
+template <typename Scalar>
+void Mathematica::write_elem(std::ostream& out, Scalar value) const {
+    assert_dbg(out, ExcIO());
+    if (m_check_for_thresh && std::abs(value) < m_thresh) {
+        out << 0;
+    } else {
+        out << value;
+    }
+}
+
+void Mathematica::write_comment(std::ostream& out,
+                                const std::string& comment) const {
+    out << "(* " << comment << " *)" << std::endl;
+}
+
+}  // namespace io
+}  // namespace linalgwrap

--- a/src/linalgwrap/io/MatrixPrinter.hh
+++ b/src/linalgwrap/io/MatrixPrinter.hh
@@ -120,7 +120,7 @@ class MatrixPrinter {
 //
 
 inline MatrixPrinter::MatrixPrinter()
-      : m_max_screen_width(80), m_known_zero_char('*'){};
+      : m_max_screen_width(80), m_known_zero_char('*') {}
 
 inline void MatrixPrinter::max_screen_width(std::streamsize w) {
     m_max_screen_width = w;

--- a/src/linalgwrap/io/MatrixPrinter.hh
+++ b/src/linalgwrap/io/MatrixPrinter.hh
@@ -1,0 +1,241 @@
+//
+// Copyright (C) 2016 by the linalgwrap authors
+//
+// This file is part of linalgwrap.
+//
+// linalgwrap is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// linalgwrap is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with linalgwrap. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+#include "OstreamState.hh"
+#include <linalgwrap/Constants.hh>
+#include <linalgwrap/Matrix_i.hh>
+#include <ostream>
+
+namespace linalgwrap {
+
+// Forward declaration
+template <typename Scalar>
+class Matrix_i;
+
+namespace io {
+
+/** Class to print a matrix to an ostream such that
+ *  the maximum number of sensible information can be
+ *  noted from it.
+ *
+ *  The idea is to use this class when printing to cout
+ *  or cerr or similar, i.e. output streams where the
+ *  user directly sees what is written.
+ */
+class MatrixPrinter {
+    // This is a really quick and dirty implementation.
+    //
+    // For some ideas on how to do this more cleverly look at
+    // /usr/include/armadillo_bits/arma_ostream_bones.hpp
+    // /usr/include/armadillo_bits/arma_ostream_meat.hpp
+
+  public:
+    /** Default constructor */
+    MatrixPrinter();
+
+    /** \name Properties */
+    ///@{
+    /** \brief Set the maximal screen width assumed in this class
+     *
+     * We try to keep the number of columns used for printing smaller than
+     * this value.
+     * */
+    void max_screen_width(std::streamsize w);
+
+    /** \brief Get the maximal screen width assumed in this class
+     * */
+    std::streamsize max_screen_width() const;
+
+    /** \brief Set the character prepended to a known zero.
+     *
+     * Via the notion of sparsity patterns and iterators the library knows
+     * of the locations of some zero values. These are maked in the printed
+     * string via this character.
+     * */
+    void known_zero_character(char c);
+
+    /** \brief Get the character prepended to a known zero.
+     * */
+    char known_zero_character() const;
+    ///@}
+
+    /** Print a generic matrix to the ostream */
+    template <typename Scalar>
+    void print(const Matrix_i<Scalar>&, std::ostream& out) const;
+
+  private:
+    /** Determine the width to use for each element and
+     * set the formatting flags of the ostream
+     *
+     * \param mat  The matrix to scan
+     * */
+    template <typename Scalar>
+    std::streamsize determine_width(const Matrix_i<Scalar>& mat,
+                                    std::ostream& out) const;
+
+    /** Print a single element to the ostream, given an actual width
+     *
+     * \param elem    The element to print
+     * \param width   The width to use
+     * \param out     The output stream to print to
+     * */
+    template <typename Scalar>
+    void print_elem(const Scalar& elem, std::streamsize width,
+                    std::ostream& out) const;
+
+    /** Print a zero, either one which is or is not explicitly stored
+     *
+     * \param stored   Is the zero explicitly stored?
+     * */
+    void print_zero(bool stored, std::streamsize width,
+                    std::ostream& out) const;
+
+    /** Assumed maximal screen width */
+    std::streamsize m_max_screen_width;
+
+    /** The character to append to 0 in order to indicate that
+     *  this zero is not explicitly stored */
+    char m_known_zero_char;
+};
+
+//
+// ------------------------------------------------
+//
+
+inline MatrixPrinter::MatrixPrinter()
+      : m_max_screen_width(80), m_known_zero_char('*'){};
+
+inline void MatrixPrinter::max_screen_width(std::streamsize w) {
+    m_max_screen_width = w;
+}
+
+inline std::streamsize MatrixPrinter::max_screen_width() const {
+    return m_max_screen_width;
+}
+
+inline void MatrixPrinter::known_zero_character(char c) {
+    m_known_zero_char = c;
+}
+
+inline char MatrixPrinter::known_zero_character() const {
+    return m_known_zero_char;
+}
+
+template <typename Scalar>
+void MatrixPrinter::print(const Matrix_i<Scalar>& mat,
+                          std::ostream& out) const {
+    typedef typename Matrix_i<Scalar>::size_type size_type;
+
+    // TODO Truncate the number of rows and columns which are
+    // printed once it gets too many
+
+    assert_dbg(out, ExcIO());
+
+    // Save ostream state
+    // Upon destruction of this class the state is automatically
+    // restored to what it was before.
+    OstreamState state(out);
+
+    // Determine width:
+    std::streamsize width = determine_width(mat, out);
+
+    // Here we use the fact that iterators are designed to skip known zero
+    // elements. Hence if we traverse the matrix using an iterator and
+    // by looping over all matrix elements, we know for sure that those
+    // we do not reach via the iterator are not stored!
+    auto it = std::begin(mat);
+    for (size_type row = 0; row < mat.n_rows(); ++row) {
+        for (size_type col = 0; col < mat.n_cols(); ++col) {
+            if (it.col() == col && it.row() == row) {
+                // Element can be reached via the iterator
+                // => not a known zero
+                print_elem(*it, width, out);
+                ++it;
+            } else {
+                // Element cannot be reached via the iterator
+                // => known zero.
+                print_zero(false, width, out);
+            }
+        }
+        out << std::endl;
+    }
+}
+
+template <typename Scalar>
+std::streamsize MatrixPrinter::determine_width(const Matrix_i<Scalar>&,
+                                               std::ostream& out) const {
+    using namespace std;
+    // TODO have different cases here. See armadillo for ideas
+    // TODO consider m_max_screen_width
+
+    // Change stream flags:
+    out.unsetf(ios::showbase);
+    out.unsetf(ios::uppercase);
+    out.unsetf(ios::showpos);
+    out.setf(ios::scientific);
+    out.setf(ios::right);
+    out.unsetf(ios::fixed);
+    out.fill(' ');
+    out.precision(4);
+
+    // Calculate and set width:
+    // 1   Empty space
+    // 3   Minus, number and .
+    // 4   precision
+    // 5   e+?? and space
+    streamsize width = 1 + 3 + 4 + 4;
+
+    return width;
+}
+
+template <typename Scalar>
+void MatrixPrinter::print_elem(const Scalar& elem, std::streamsize width,
+                               std::ostream& out) const {
+    // TODO Do something special for NaN and Inf
+
+    if (elem == Constants<Scalar>::zero) {
+        print_zero(true, width, out);
+        return;
+    }
+
+    // For some reason we need to set this each time ...
+    out.width(width);
+    out << elem;
+}
+
+inline void MatrixPrinter::print_zero(bool stored, std::streamsize width,
+                                      std::ostream& out) const {
+    // For some reason we need to set this each time ...
+    if (!stored) {
+        // Build string:
+        std::stringstream s;
+        s << m_known_zero_char;
+        s << "0";
+
+        out.width(width);
+        out << s.str();
+    } else {
+        out.width(width);
+        out << "0";
+    }
+}
+
+}  // namespace io
+}  // namespace linalgwrap

--- a/src/linalgwrap/io/OstreamState.hh
+++ b/src/linalgwrap/io/OstreamState.hh
@@ -1,0 +1,95 @@
+//
+// Copyright (C) 2016 by the linalgwrap authors
+//
+// This file is part of linalgwrap.
+//
+// linalgwrap is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// linalgwrap is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with linalgwrap. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+#include <ios>
+#include <ostream>
+
+namespace linalgwrap {
+namespace io {
+
+/** Class to store a current internal state of an ostream
+ * and restore it upon destruction of the class.
+ */
+class OstreamState {
+  public:
+    //! Construct from an ostream, taking its current state
+    OstreamState(std::ostream& o);
+
+    //! Destruct class, set state back to the ostream.
+    ~OstreamState();
+
+    //! Default copy constructor
+    OstreamState(const OstreamState&) = default;
+
+    //! Default move constructor
+    OstreamState(OstreamState&&) = default;
+
+    //! Default copy assignment
+    OstreamState& operator=(const OstreamState&) = default;
+
+    //! Default move assignment
+    OstreamState& operator=(OstreamState&&) = default;
+
+    /** Set original state to this ostream as well
+     *
+     *  \note This class automatically resets the state of the ostream passed
+     *  upon construction as soon as it is destructed.
+     **/
+    void restore_to(std::ostream& o) const;
+
+  private:
+    //! The ostream we manage
+    std::ostream& m_o;
+
+    //! The original format flags it had:
+    std::ios::fmtflags m_orig_flags;
+
+    //! The original stream width it had:
+    std::streamsize m_orig_width;
+
+    //! The original precision it had:
+    std::streamsize m_orig_precision;
+
+    //! The original fill character it had:
+    char m_orig_fill;
+};
+
+//
+// --------------------------------------
+//
+
+inline OstreamState::OstreamState(std::ostream& o)
+      : m_o{o},
+        m_orig_flags{o.flags()},
+        m_orig_width{o.width()},
+        m_orig_precision{o.precision()},
+        m_orig_fill{o.fill()} {}
+
+inline OstreamState::~OstreamState() { restore_to(m_o); }
+
+inline void OstreamState::restore_to(std::ostream& o) const {
+    o.flags(m_orig_flags);
+    o.width(m_orig_width);
+    o.precision(m_orig_precision);
+    o.fill(m_orig_fill);
+}
+
+}  // namespace io
+}  // namespace linalgwrap


### PR DESCRIPTION
Matrix printing is now performed in the io::MatrixPrinter
The idea is to extend this and perform sensible printing
such that as much information is displayed as detailed
as possible to a user on a cout or cerr stream.
Matrix_i now uses this to implement the << operator.
The intention is that this should be used for printing
to stdout/stderr.

For printing to files the DataOut_i interface and the FileTypeWriter is
available. The only currently supported output format is Mathematica.