### PR TITLE
Add include_directory to findKrims.cmake

### DIFF
--- a/cmake/findKrims.cmake
+++ b/cmake/findKrims.cmake
@@ -62,6 +62,7 @@ if ("${krims_DIR}" STREQUAL "krims_DIR-NOTFOUND")
 		# Proceed to configure krims
 		#
 		add_subdirectory(${PROJECT_SOURCE_DIR}/external/krims)
+		include_directories(${PROJECT_SOURCE_DIR}/external/krims/src)
 
 		# TODO check version of krims!
 


### PR DESCRIPTION
Such that the krims includes are also available if git checkout are
performed.