### PR TITLE
Implementation of a VectorMemoryWrapper

### DIFF
--- a/src/linalgwrap/Armadillo/ArmadilloVector.hh
+++ b/src/linalgwrap/Armadillo/ArmadilloVector.hh
@@ -33,7 +33,7 @@ template <typename Scalar>
 class ArmadilloMatrix;
 
 template <typename Scalar>
-class ArmadilloVector : public StoredVector_i<Scalar> {
+class ArmadilloVector : public MutableVector_i<Scalar>, public Stored_i {
     static_assert(
           std::is_same<double, Scalar>::value ||
                 std::is_same<float, Scalar>::value ||
@@ -51,7 +51,7 @@ class ArmadilloVector : public StoredVector_i<Scalar> {
           "int, unsigned long");
 
   public:
-    typedef StoredVector_i<Scalar> base_type;
+    typedef MutableVector_i<Scalar> base_type;
     typedef typename base_type::scalar_type scalar_type;
     typedef typename base_type::size_type size_type;
     typedef typename base_type::real_type real_type;

--- a/src/linalgwrap/BaseInterfaces/IsStoredVector.hh
+++ b/src/linalgwrap/BaseInterfaces/IsStoredVector.hh
@@ -19,16 +19,22 @@
 
 #pragma once
 #include "MutableVector_i.hh"
+#include "Stored_i.hh"
 
 namespace linalgwrap {
 
-/** \brief Abstract vector interface class to represent a vector, that
- *   manages its storage.
+/** \brief struct representing a type (std::true_type, std::false_type) which
+ *  indicates whether T is a stored vector.
+ *
+ *  A stored vector is a mutable vector, which also inherits off the
+ *  Stored_i marker class.
+ *
+ *  The expectation is that it satisfies the following:
  *
  * If the object is not const both read and write access to the data is
  * given.
  *
- * We expect any implementing class to also provide the following constructors:
+ * We expect any stored vector class to also provide the following constructors:
  * - Construct vector of fixed size and optionally fill with zeros or leave
  *   memory unassigned:
  *   ```
@@ -63,7 +69,7 @@ namespace linalgwrap {
  * The following types should also be defined:
  *  - iterator  The type returned by begin()
  *  - const_iterator The type returned by cbegin()
- *  - matrix_type  The type of the corresponding stored matrix.
+ *  - matrix_type  The type of the corresponding stored matrix (or void if none)
  *
  * The following methods should be implemented:
  *  - ``begin()``, ``cbegin()``  Return an iterator or a constant iterator
@@ -71,21 +77,11 @@ namespace linalgwrap {
  *  - ``end()``, ``cend()``   Return an iterator/constant iterator to the
  *    position past-the-end of the stride of memory.
  */
-template <typename Scalar>
-class StoredVector_i : public MutableVector_i<Scalar> {
-    // Just forward from MutableVector_i
-};
-
-//@{
-/** \brief struct representing a type (std::true_type, std::false_type) which
- *  indicates whether T is a stored vector.
- *  */
-template <typename T, typename = void>
-struct IsStoredVector : public std::false_type {};
 
 template <typename T>
-struct IsStoredVector<T, krims::VoidType<typename T::scalar_type>>
-      : public std::is_base_of<StoredVector_i<typename T::scalar_type>, T> {};
-//@}
+struct IsStoredVector : public std::integral_constant<
+                              bool, IsMutableVector<T>::value &&
+                                          std::is_base_of<Stored_i, T>::value> {
+};
 
 }  // namespace linalgwrap

--- a/src/linalgwrap/BaseInterfaces/Stored_i.hh
+++ b/src/linalgwrap/BaseInterfaces/Stored_i.hh
@@ -18,21 +18,15 @@
 //
 
 #pragma once
-/** \file Includes the most basic inferfaces along with the
- * default implementation for all important operations */
 
-/** Signal the calling of fallback functions by printing to cerr
- *  (useful for debugging whether the specialisations have worked) */
-//#define LINALGWRAP_SIGNAL_FALLBACK
-
-// Basic interfaces
-#include "BaseInterfaces/Indexable_i.hh"
-#include "BaseInterfaces/Stored_i.hh"
-
-// Vectors
-#include "BaseInterfaces/IsStoredVector.hh"
-#include "BaseInterfaces/MutableVector_i.hh"
-#include "BaseInterfaces/Vector_i.hh"
-
-// Default implementations for important Vector operations.
-#include "BaseInterfaces/FallbackOperations.hh"
+namespace linalgwrap {
+/** Marker interface to assert that the objects derived off this class are
+ * stored, i.e. that they manage their own storage allocation and deallocation
+ * internally.
+ *
+ * This has certain implications on the type of constructors which are to be
+ * present.
+ * See IsStoredVector.hh for details.
+ */
+struct Stored_i {};
+}

--- a/src/linalgwrap/Builtin/BuiltinVector.hh
+++ b/src/linalgwrap/Builtin/BuiltinVector.hh
@@ -27,7 +27,7 @@ namespace linalgwrap {
 
 /** A very basic class for a stored vector */
 template <typename Scalar>
-class BuiltinVector : public StoredVector_i<Scalar> {
+class BuiltinVector : public Stored_i, public MutableVector_i<Scalar> {
   public:
     typedef StoredVector_i<Scalar> base_type;
     typedef typename base_type::scalar_type scalar_type;

--- a/src/linalgwrap/VectorMemoryWrapper.hh
+++ b/src/linalgwrap/VectorMemoryWrapper.hh
@@ -1,0 +1,323 @@
+//
+// Copyright (C) 2016 by the linalgwrap authors
+//
+// This file is part of linalgwrap.
+//
+// linalgwrap is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// linalgwrap is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with linalgwrap. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+#include "linalgwrap/BaseInterfaces.hh"
+
+namespace linalgwrap {
+namespace detail {
+template <typename T>
+struct MakeConstIterator {
+    typedef std::iterator_traits<T> tt;
+
+    struct type : public T {
+        typedef typename tt::iterator_category iterator_category;
+        typedef
+              typename std::add_const<typename tt::value_type>::type value_type;
+        typedef typename tt::difference_type difference_type;
+        typedef const typename tt::pointer pointer;
+        typedef const typename tt::reference reference;
+
+        type(T t) : T(t) {}
+        reference operator*() const { return T::operator*(); }
+        pointer operator->() const { return T::operator->(); }
+    };
+};
+
+template <typename T>
+struct MakeConstIterator<T*> {
+    typedef const T* type;
+};
+
+template <typename T>
+struct MakeConstIterator<const T*> {
+    typedef const T* type;
+};
+}  // namespace detail
+
+/** \brief Simple class to offer a vector-like view into an arbitrary stride
+ * of memory.
+ *
+ * The memory is either specified by an iterator range or
+ * by an initial position and a size.
+ *
+ * \tparam Iterator   the iterator which represents the range of memory
+ * \tparam ConstIterator   the type of the equivalent const iterator.
+ *                         If missing it will either be deduced or if not
+ * possible
+ *                         a constant access view will be employed.
+ */
+template <typename Iterator,
+          typename ConstIterator =
+                typename detail::MakeConstIterator<Iterator>::type>
+class VectorMemoryWrapper
+      : public MutableVector_i<typename std::decay<
+              typename std::iterator_traits<Iterator>::value_type>::type> {
+  public:
+    //@{
+    //! The iterator types
+    typedef Iterator iterator;
+    typedef ConstIterator const_iterator;
+    //@}
+
+    typedef typename std::decay<typename std::iterator_traits<
+          iterator>::value_type>::type scalar_type;
+    typedef MutableVector_i<scalar_type> base_type;
+    typedef typename base_type::size_type size_type;
+    typedef typename base_type::real_type real_type;
+
+    /** \name Constructors */
+    ///@{
+    /** \brief Construct a VectorMemoryWrapper over an iterator range.  */
+    VectorMemoryWrapper(iterator begin, iterator end) {
+        initialise(std::forward<iterator>(begin), std::forward<iterator>(end));
+    }
+
+    /** \brief Construct a VectorMemoryWrapper by providing a start of the range
+     * and a size
+     *
+     * \param size Number of elements this container holds, including the one
+     * pointed to by begin
+     * */
+    VectorMemoryWrapper(iterator begin, size_type size) {
+        initialise(std::forward<iterator>(begin), size);
+    }
+
+    /** \name Size of the vector */
+    size_type n_elem() const override { return m_size; }
+
+    /** \name Size of the vector */
+    size_type size() const override { return m_size; }
+
+    /** \name Data access
+     */
+    ///@{
+    /** \brief return an element of the vector    */
+    scalar_type operator()(size_type i) const override {
+        // assertion done in operator[]
+        return (*this)[i];
+    }
+
+    /** \brief return an element of the vector */
+    scalar_type operator[](size_type i) const override;
+
+    /** \brief return an element of the vector    */
+    scalar_type& operator()(size_type i) override {
+        // assertion done in operator[]
+        return (*this)[i];
+    }
+
+    /** \brief return an element of the vector */
+    scalar_type& operator[](size_type i) override;
+    ///@}
+
+    /** Set all elements of the vector to zero */
+    virtual void set_zero() override {
+        std::fill(begin(), end(), Constants<scalar_type>::zero);
+    }
+
+    /** \name Iterators
+     */
+    ///@{
+    /** Return an iterator to the beginning */
+    iterator begin() { return m_begin; }
+
+    /** Return a const_iterator to the beginning */
+    const_iterator begin() const { return cbegin(); }
+
+    /** Return a const_iterator to the beginning */
+    const_iterator cbegin() const { return const_iterator(m_begin); }
+
+    /** Return an iterator to the end */
+    iterator end() { return m_end; }
+
+    /** Return a const_iterator to the end */
+    const_iterator end() const { return cend(); }
+
+    /** Return a const_iterator to the end */
+    const_iterator cend() const { return const_iterator(m_end); }
+    ///@}
+
+    /** \name Vector operations */
+    ///@{
+    /** Scale vector by a scalar value */
+    VectorMemoryWrapper& operator*=(scalar_type s) {
+        assert_finite(s);
+        std::transform(begin(), end(), begin(),
+                       [&](scalar_type& v) { return v * s; });
+        return *this;
+    }
+
+    /** Divide all vector entries by a scalar value */
+    VectorMemoryWrapper& operator/=(scalar_type s) {
+        assert_nonzero(s);
+        assert_finite(s);
+        std::transform(begin(), end(), begin(),
+                       [&](scalar_type& v) { return v / s; });
+        return *this;
+    }
+
+    /* Add a vector to this one */
+    VectorMemoryWrapper& operator+=(const VectorMemoryWrapper& other) {
+        assert_size(n_elem(), other.n_elem());
+        std::transform(
+              begin(), end(), std::begin(other), begin(),
+              [](scalar_type& v1, scalar_type& v2) { return v1 + v2; });
+        return *this;
+    }
+
+    /* Add a vector to this one */
+    VectorMemoryWrapper& operator-=(const VectorMemoryWrapper& other) {
+        assert_size(n_elem(), other.n_elem());
+        std::transform(
+              begin(), end(), std::begin(other), begin(),
+              [](scalar_type& v1, scalar_type& v2) { return v1 - v2; });
+        return *this;
+    }
+
+    bool operator==(const VectorMemoryWrapper& other) const {
+        if (m_size != other.m_size) return false;
+        return std::equal(begin(), end(), std::begin(other));
+    }
+
+  protected:
+    /** Allow deferred initialisation construction
+     *
+     * Before this class is used you *must* call initialise.
+     **/
+    VectorMemoryWrapper() {}
+
+    /** Initialise from range */
+    void initialise(iterator begin, iterator end);
+
+    /** Initialise from begin and size */
+    void initialise(iterator begin, size_type size);
+
+    iterator m_begin;
+    iterator m_end;
+    size_type m_size;
+};
+
+/** Convenience function to construct a vector memory wrapper class */
+template <typename Iterator>
+VectorMemoryWrapper<Iterator> make_vector_mem_wrap(Iterator begin,
+                                                   Iterator end) {
+    return VectorMemoryWrapper<Iterator>(begin, end);
+}
+
+/** Convenience function to construct a vector memory wrapper class */
+template <typename Iterator, typename Size>
+VectorMemoryWrapper<Iterator> make_vector_mem_wrap(Iterator begin, Size size) {
+    return VectorMemoryWrapper<Iterator>(begin, size);
+}
+
+//
+// Standard operations
+//
+template <typename Iterator, typename ConstIterator>
+VectorMemoryWrapper<Iterator, ConstIterator> operator*(
+      typename VectorMemoryWrapper<Iterator, ConstIterator>::scalar_type s,
+      VectorMemoryWrapper<Iterator, ConstIterator> m) {
+    m *= s;
+    return m;
+}
+
+template <typename Iterator, typename ConstIterator>
+VectorMemoryWrapper<Iterator, ConstIterator> operator*(
+      VectorMemoryWrapper<Iterator, ConstIterator> m,
+      typename VectorMemoryWrapper<Iterator, ConstIterator>::scalar_type s) {
+    return s * m;
+}
+
+template <typename Iterator, typename ConstIterator>
+VectorMemoryWrapper<Iterator, ConstIterator> operator/(
+      VectorMemoryWrapper<Iterator, ConstIterator> m,
+      typename VectorMemoryWrapper<Iterator, ConstIterator>::scalar_type s) {
+    m /= s;
+    return m;
+}
+
+template <typename Iterator, typename ConstIterator>
+VectorMemoryWrapper<Iterator, ConstIterator> operator-(
+      VectorMemoryWrapper<Iterator, ConstIterator> mat) {
+    typedef typename VectorMemoryWrapper<Iterator, ConstIterator>::scalar_type
+          scalar_type;
+    return -Constants<scalar_type>::one * mat;
+}
+
+//
+// Add and subtract
+//
+template <typename Iterator, typename ConstIterator>
+VectorMemoryWrapper<Iterator, ConstIterator> operator-(
+      VectorMemoryWrapper<Iterator, ConstIterator> lhs,
+      const VectorMemoryWrapper<Iterator, ConstIterator>& rhs) {
+    lhs -= rhs;
+    return lhs;
+}
+
+template <typename Iterator, typename ConstIterator>
+VectorMemoryWrapper<Iterator, ConstIterator> operator+(
+      VectorMemoryWrapper<Iterator, ConstIterator> lhs,
+      const VectorMemoryWrapper<Iterator, ConstIterator>& rhs) {
+    lhs += rhs;
+    return lhs;
+}
+
+//
+// -------------------------------------------------------------
+//
+
+template <typename Iterator, typename ConstIterator>
+typename VectorMemoryWrapper<Iterator, ConstIterator>::scalar_type
+      VectorMemoryWrapper<Iterator, ConstIterator>::operator[](
+            size_type i) const {
+    assert_range(0, i, n_elem());
+    iterator cpy(m_begin);
+    std::advance(cpy, i);
+    return *cpy;
+}
+
+template <typename Iterator, typename ConstIterator>
+typename VectorMemoryWrapper<Iterator, ConstIterator>::scalar_type&
+      VectorMemoryWrapper<Iterator, ConstIterator>::operator[](size_type i) {
+    assert_range(0, i, n_elem());
+    iterator cpy(m_begin);
+    std::advance(cpy, i);
+    return *cpy;
+}
+
+template <typename Iterator, typename ConstIterator>
+void VectorMemoryWrapper<Iterator, ConstIterator>::initialise(iterator begin,
+                                                              iterator end) {
+    m_begin = std::move(begin);
+    m_end = std::move(end);
+    m_size = std::distance(m_begin, m_end);
+}
+
+template <typename Iterator, typename ConstIterator>
+void VectorMemoryWrapper<Iterator, ConstIterator>::initialise(iterator begin,
+                                                              size_type size) {
+    m_begin = std::move(begin);
+    m_end = m_begin;
+    m_size = size;
+    std::advance(m_end, m_size);
+}
+
+}  // end namespace linalgwrap

--- a/tests/ArmadilloVectorTests.cc
+++ b/tests/ArmadilloVectorTests.cc
@@ -29,7 +29,7 @@ using namespace rc;
 
 #ifdef LINALGWRAP_HAVE_ARMADILLO
 template <typename S>
-using genlib = stored_vector_tests::GeneratorLibrary<ArmadilloVector<S>>;
+using genlib = vector_tests::GeneratorLibrary<ArmadilloVector<S>>;
 
 TEST_CASE("ArmadilloVector class", "[ArmadilloVector]") {
     SECTION("Test initializer_list construction") {
@@ -60,7 +60,7 @@ TEST_CASE("ArmadilloVector class", "[ArmadilloVector]") {
                   0.1 * krims::NumCompConstants::default_tolerance_factor);
 
             stored_vector_tests::run_with_generator(
-                  genlib<double>::generator(), "ArmadilloVector<double>: ");
+                  genlib<double>::testgenerator(), "ArmadilloVector<double>: ");
         }
 
         // TODO improve the accuracy for complex vectors:
@@ -69,7 +69,7 @@ TEST_CASE("ArmadilloVector class", "[ArmadilloVector]") {
               10. * krims::NumCompConstants::default_tolerance_factor);
 
         stored_vector_tests::run_with_generator(
-              genlib<std::complex<double>>::generator(),
+              genlib<std::complex<double>>::testgenerator(),
               "ArmadilloVector<complex double>: ");
     }
 }

--- a/tests/BuiltinVectorTests.cc
+++ b/tests/BuiltinVectorTests.cc
@@ -26,7 +26,7 @@ namespace builtin_vector_tests {
 using namespace rc;
 
 template <typename S>
-using genlib = stored_vector_tests::GeneratorLibrary<BuiltinVector<S>>;
+using genlib = vector_tests::GeneratorLibrary<BuiltinVector<S>>;
 
 TEST_CASE("BuiltinVector class", "[BuiltinVector]") {
     SECTION("Default stored vector tests") {
@@ -35,11 +35,11 @@ TEST_CASE("BuiltinVector class", "[BuiltinVector]") {
         auto lowertol = NumCompConstants::change_temporary(
               0.1 * krims::NumCompConstants::default_tolerance_factor);
 
-        stored_vector_tests::run_with_generator(genlib<double>::generator(),
+        stored_vector_tests::run_with_generator(genlib<double>::testgenerator(),
                                                 "BuiltinVector<double>: ");
 
         stored_vector_tests::run_with_generator(
-              genlib<std::complex<double>>::generator(),
+              genlib<std::complex<double>>::testgenerator(),
               "BuiltinVector<complex double>: ");
     }
 }

--- a/tests/RCTestableGenerator.hh
+++ b/tests/RCTestableGenerator.hh
@@ -92,6 +92,17 @@ struct RCTestableGenerator {
             model_generator([](args_type t) { return model_type{t}; }),
             sut_generator([](args_type t) { return sut_type{t}; }) {}
 
+    /** \brief Construct a RCTestableGenerator object.
+     *
+     * Use explicit conversion to the model_type to obtain
+     * the model from the args
+     */
+    RCTestableGenerator(std::function<args_type(void)> args_generator_,
+                        std::function<sut_type(args_type)> sut_generator_)
+          : args_generator(args_generator_),
+            model_generator([](args_type t) { return model_type{t}; }),
+            sut_generator(sut_generator_) {}
+
     /* Return a std::function object that creates random arguments of type
      * args_type, then passes them to the model_generator and the sut_generator
      * to generate a model and a sut and then calles the testfunction func

--- a/tests/mutable_vector_tests.hh
+++ b/tests/mutable_vector_tests.hh
@@ -96,6 +96,12 @@ struct ComparativeTests : public vector_tests::ComparativeTests<Model, Sut> {
                         const std::string& prefix);
 };
 
+template <typename Model, typename Sut, typename Args>
+void run_with_generator(const RCTestableGenerator<Model, Sut, Args>& gen,
+                        const std::string prefix = "") {
+    ComparativeTests<Model, Sut>::run_all(gen, prefix);
+}
+
 //
 // -------------------------------------------------------
 //

--- a/tests/stored_vector_tests.hh
+++ b/tests/stored_vector_tests.hh
@@ -63,40 +63,6 @@ struct ComparativeTests
     static void once_test_as_scalar();
 };
 
-template <typename Vector,
-          typename Model =
-                indexable_tests::VectorModel<typename Vector::scalar_type>>
-struct GeneratorLibrary {
-    /** The type we test */
-    typedef Vector vector_type;
-
-    /** The scalar type of the vector */
-    typedef typename vector_type::scalar_type scalar_type;
-
-    /** The return type of the argsgen function */
-    typedef std::vector<scalar_type> args_type;
-
-    /** The type of the model we use */
-    typedef Model model_type;
-
-    /** The type of the testable generator */
-    typedef RCTestableGenerator<model_type, vector_type, args_type> gen_type;
-
-    /** The argument generator we use */
-    static constexpr args_type argsgen() {
-        return *gen::scale(genscale,
-                           gen::numeric_container<std::vector<scalar_type>>())
-                      .as("Vector data");
-    }
-
-    /** Get the generator for the specified vector type */
-    static gen_type generator() { return gen_type(argsgen); }
-
-  private:
-    static constexpr bool cplx = krims::IsComplexNumber<scalar_type>::value;
-    static constexpr double genscale = cplx ? 0.8 : 1.0;
-};
-
 template <typename Model, typename Sut, typename Args>
 void run_with_generator(const RCTestableGenerator<Model, Sut, Args>& gen,
                         const std::string prefix = "") {

--- a/tests/vector_tests.hh
+++ b/tests/vector_tests.hh
@@ -29,6 +29,54 @@ using namespace krims;
  **/
 namespace vector_tests {
 
+/** \brief Generator library for vector tests
+ *
+ * \tparam Vector The vector type to test.
+ * \tparam Args The arguments the argsgen function produces
+ * \tparam Model The model type to use
+ */
+template <typename Vector,
+          typename Args = std::vector<typename Vector::scalar_type>,
+          typename Model =
+                indexable_tests::VectorModel<typename Vector::scalar_type>>
+struct GeneratorLibrary {
+    /** The args type to use */
+    typedef Args args_type;
+
+    /** The type of model to use */
+    typedef Model model_type;
+
+    /** The vector to test */
+    typedef Vector vector_type;
+
+    /** The type of the testable generator */
+    typedef RCTestableGenerator<model_type, vector_type, args_type>
+          testgen_type;
+
+    /** The argument generator we use */
+    static constexpr args_type argsgen() {
+        return *gen::scale(genscale, gen::numeric_container<args_type>())
+                      .as("Data");
+    }
+
+    /** Get the generator for tests using the specified generator for the vector
+     *
+     * \param vectorgen The generator to generate the vector to test from the
+     * arguments. By default a simple conversion is performed.
+     */
+    static testgen_type testgenerator(std::function<Vector(Args)> vectorgen =
+                                            [](args_type t) {
+                                                return Vector(t);
+                                            }) {
+        return testgen_type(argsgen, vectorgen);
+    }
+
+  private:
+    static constexpr bool cplx =
+          krims::IsComplexNumber<typename Vector::scalar_type>::value;
+    static constexpr double genscale = cplx ? 0.8 : 1.0;
+};
+
 /** \brief Standard test functions which test a certain
  *  functionality by executing it in the SutVector
  *  and in a ModelVector and comparing the results


### PR DESCRIPTION
The VectorMemoryWrapper allows to enwrap some memory (or an iterator range) and access it like a normal vector, including the standard vector operations.