### PR TITLE
Add Lapack eigensolvers dspgv and dspev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ env:
     - RC_PARAMS="seed=16920708173099178154 verbose_progress=1 noshrink=1"
     #
     # Dependencies we need to install
-    - DEPEND_PKG="libarmadillo-dev libboost-dev"
+    - DEPEND_PKG="libarmadillo-dev libboost-dev liblapack-dev libblas-dev"
 
 matrix:
   include:

--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -50,6 +50,7 @@ flags = [
     # Compile extra code blocks:
     '-DLINALGWRAP_HAVE_ARMADILLO',
     '-DLINALGWRAP_HAVE_ARPACK',
+    '-DLINALGWRAP_HAVE_LAPACK',
     # C++14 code blocks:
     '-DLINALGWRAP_HAVE_CXX14',
     '-DKRIMS_HAVE_CXX14',

--- a/README.md
+++ b/README.md
@@ -11,20 +11,25 @@ and only a fraction of the planned features are currently implemented.
 ## Dependencies
 ``linalgwrap`` depends on the following libraries:
 - [krims](https://linalgwrap.org/krims) for many basic utilities
-  (ParameterMap, Exception handling, Subscription pointers)
-- [armadillo](http://arma.sourceforge.net/) as the only supported
-  linear-algebra backend (so far)
-- *(optional)* [ARPACK](http://www.caam.rice.edu/software/ARPACK/) in order to use ``linalgwrap`` with the
-  ARPACK eigensolver.
+  (GenMap, Exception handling, Subscription pointers)
+- A BLAS implementation, e.g. [OpenBLAS](https://github.com/xianyi/OpenBLAS/)
+- A LAPACK compatible library, e.g.
+  [LAPACK](http://netlib.org/lapack) in order to use ``linalgwrap`` the
+  LAPACK eigensolvers
+- [armadillo](http://arma.sourceforge.net/) for the armadillo eigensolvers
+  and linear solvers as well as the only linear-algebra backend (so far)
+- *(optional)* [ARPACK](http://www.caam.rice.edu/software/ARPACK/) in order to use
+  ``linalgwrap`` with the ARPACK eigensolver.
 
 Testing ``linalgwrap`` further requires
 - [Catch](https://github.com/philsquared/Catch/) for the testing environment
 - [rapidcheck](https://github.com/emil-e/rapidcheck) for property-based testing
 
 Note, that for building ``linalgwrap`` (see [below](#building)) you really only need to have
-[armadillo](http://arma.sourceforge.net/) installed on your system.
+[armadillo](http://arma.sourceforge.net/), [LAPACK](http://netlib.org/lapack) and a BLAS
+installed on your system.
 All other dependencies can be automatically downloaded during the build process
-if you choose to so (set ``AUTOCHECKOUT_MISSING_REPOS`` to ``ON``,
+if you choose to do so (set ``AUTOCHECKOUT_MISSING_REPOS`` to ``ON``,
 more below)
 
 ## Building
@@ -135,14 +140,16 @@ On global scope we have:
   since their interface is designed to be easy to use and it easy to enforce
   a particular eigensolver explicitly (using the parameter key ``method``).
 - For linear problems the file [solve.hh](src/linalgwrap/solve.hh) similarly
-  contains the methods  ``solve`` and ``solve_hermitian``.
+  contains the method  ``solve``.
 - The folder [Base/Solvers](src/linalgwrap/Base/Solvers) holds all the lower
-  interfaces the solvers use.
-- Currently only [ArpackEigensolver](src/linalgwrap/ArpackEigensolver.hh)
-  and [ArmadilloEigensolver](src/linalgwrap/ArmadilloEigensolver.hh) are implemented
-  as eigensolver backends.
+  interfaces and some utilities the actual solvers use.
+- Currently only [ArpackEigensolver](src/linalgwrap/Arpack/ArpackEigensolver.hh)
+  and some eigensolvers from Lapack (either indirectly via
+  [ArmadilloEigensolver](src/linalgwrap/Armadillo/ArmadilloEigensolver.hh)
+  or directy via [LapackEigensolver](src/linalgwrap/Lapack/LapackEigensolver.hh))
+  are implemented as eigensolver backends.
 - ARPACK is enabled if it is found on the system.
-- Right now linear problems are always solved with ``armadillo``.
+- Linear problems are always solved with ``LAPACK`` via  ``armadillo`` right now.
 
 ### TestingUtils
 This class contains utilities for performing numerics-aware

--- a/cmake/setup_dependencies.cmake
+++ b/cmake/setup_dependencies.cmake
@@ -68,7 +68,6 @@ endforeach()
 #################
 #-- armadillo --#
 #################
-include(FindArmadillo)
 find_package(Armadillo 4.000 REQUIRED)
 
 # add to general dependencies and include string

--- a/cmake/setup_optional.cmake
+++ b/cmake/setup_optional.cmake
@@ -43,6 +43,23 @@ if (NOT CMAKE_CXX_STANDARD VERSION_LESS 17)
 	LIST(APPEND LINALGWRAP_DEFINITIONS "LINALGWRAP_HAVE_CXX17")
 endif()
 
+#########################
+#--  LAPACK and BLAS  --#
+#########################
+set(BLAS_VENDOR "All" CACHE STRING "The BLAS and LAPACK vendor to use \
+(e.g. Intel, ATLAS, OpenBLAS, ACML, Apple)")
+set(BLA_VENDOR ${BLAS_VENDOR})
+
+find_package(LAPACK REQUIRED)
+
+# add to general dependencies
+set(LINALGWRAP_DEPENDENCIES ${LINALGWRAP_DEPENDENCIES} ${LAPACK_LIBRARIES})
+
+# enable lapack-dependant code:
+LIST(APPEND LINALGWRAP_DEFINITIONS "LINALGWRAP_HAVE_LAPACK")
+
+unset(BLA_VENDOR)
+
 ################
 #--  ARPACK  --#
 ################

--- a/src/linalgwrap/Base/Solvers.hh
+++ b/src/linalgwrap/Base/Solvers.hh
@@ -44,3 +44,6 @@
 #include "Solvers/EigensolverBase.hh"
 #include "Solvers/EigensolverBaseKeys.hh"
 #include "Solvers/EigensolverStateBase.hh"
+
+// Helper functions and utilities
+#include "Solvers/select_eigenvalues.hh"

--- a/src/linalgwrap/Base/Solvers/select_eigenvalues.hh
+++ b/src/linalgwrap/Base/Solvers/select_eigenvalues.hh
@@ -1,0 +1,153 @@
+//
+// Copyright (C) 2017 by the linalgwrap authors
+//
+// This file is part of linalgwrap.
+//
+// linalgwrap is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// linalgwrap is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with linalgwrap. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+#include <complex>
+#include <cstddef>
+#include <iterator>
+#include <krims/Algorithm.hh>
+#include <krims/ExceptionSystem.hh>
+#include <krims/TypeUtils.hh>
+
+namespace linalgwrap {
+DefException1(ExcUnknownEvalWhich, std::string, << "The vaule " << arg1
+                                                << " for which is not known");
+
+/** Comparator to use to canonically sort eigenvalues */
+struct EvalComp {
+  template <typename T, bool iscpx = krims::IsComplexNumber<T>::value>
+  bool operator()(typename std::enable_if<iscpx, T>::type i, T j) const {
+    return std::abs(i) < std::abs(j);
+  }
+
+  template <typename T, bool iscpx = krims::IsComplexNumber<T>::value>
+  bool operator()(typename std::enable_if<!iscpx, T>::type i, T j) const {
+    return i < j;
+  }
+};
+
+/** Select the n_ep eigenvalues matching the which criterion and
+ * return the index array which would produce them in sorted manor
+ * if drawn from the container.
+ *
+ * The sorting for real eigenvalues is by value and for complex ones
+ * by magnitude.
+ *
+ * This function is mainly intended for dealing with direct eigensolver
+ * methods which do not always return a sorted list of eigenpairs and
+ * moreover sometimes return many more eigenvalues than desired.
+ *
+ * \param eval_begin   The beginning of the eigenvalue range to consider
+ * \param eval_end     The end of the eigenvalue range to consider
+ * \param which        which eigenpairs to keep
+ * \param n_ep         Number of eigenpairs to keep
+ * \param sorted_canonically   May the algorithm assume that the eigenvalues
+ *                     are already sorted canonically, i.e. in the way
+ *                     the EvalComp functor above would sort them.
+ */
+template <typename Iterator>
+std::vector<size_t> select_eigenvalues(Iterator eval_begin, Iterator eval_end,
+                                       const std::string& which, const size_t n_ep,
+                                       const bool sorted_canonically = false) {
+  assert_dbg(which == "SM" || which == "LM" || which == "LR" || which == "SR" ||
+                   which == "SI" || which == "LI",
+             ExcUnknownEvalWhich(which));
+
+  typedef typename std::iterator_traits<Iterator>::value_type evalue_type;
+
+  // The size of the eigenvalue range
+  const size_t size = static_cast<size_t>(std::distance(eval_begin, eval_end));
+
+  // Is the eigenvalue type a real type
+  constexpr bool real = !krims::IsComplexNumber<evalue_type>::value;
+
+  // Is canonical sorting requested:
+  const bool want_canonical = (real && which[1] == 'R') || (!real && which[1] == 'M');
+
+  // Indices of the eigenpairs which should be kept,
+  // given in the order they should appear
+  std::vector<size_t> idcs;
+
+  if (want_canonical && sorted_canonically) {
+    // We want canonical sorting and the evals are already sorted
+    // => no work to do
+    idcs.resize(size);
+    std::iota(std::begin(idcs), std::end(idcs), 0);
+  } else {
+    using std::abs;
+    using std::real;
+    using std::imag;
+
+    if (which[1] == 'R') {
+      // Sort by real part
+      auto comp = [](const evalue_type& lhs, const evalue_type& rhs) {
+        return real(lhs) < real(rhs);
+      };
+      idcs = krims::argsort(eval_begin, eval_end, std::move(comp));
+    } else if (which[1] == 'I') {
+      // Sort by imag. part
+      auto comp = [](const evalue_type& lhs, const evalue_type& rhs) {
+        return imag(lhs) < imag(rhs);
+      };
+      idcs = krims::argsort(eval_begin, eval_end, std::move(comp));
+    } else {
+      // Sort by magnitude
+      auto comp = [](const evalue_type& lhs, const evalue_type& rhs) {
+        return abs(lhs) < abs(rhs);
+      };
+      idcs = krims::argsort(eval_begin, eval_end, std::move(comp));
+    }
+  }
+
+  // Select the eigenvalues we care about:
+  // If we want to keep the smallest we need the beginning
+  // of the range, else the end
+  size_t start = which[0] == 'S' ? 0 : size - n_ep;
+  size_t end = which[0] == 'S' ? n_ep : size;
+
+  if (want_canonical) {
+    // The ordering we just did above is the canonical ordering,
+    // which EvalComp would do anyway:
+    // => just shrink the vector to the entries we care about
+    idcs = std::vector<size_t>(std::begin(idcs) + static_cast<ptrdiff_t>(start),
+                               std::begin(idcs) + static_cast<ptrdiff_t>(end));
+  } else {
+    // Build a temporary evalues array:
+    std::vector<evalue_type> tmp;
+    tmp.reserve(end - start);
+    for (size_t i = start; i < end; ++i) {
+      tmp.push_back(*(eval_begin + idcs[i]));
+    }
+
+    // Argsort it using the default eigenpair ordering
+    std::vector<size_t> i2 = krims::argsort(std::begin(tmp), std::end(tmp), EvalComp{});
+
+    // Translate such that the desired order is included
+    std::vector<size_t> idcs_new;
+    idcs_new.reserve(i2.size());
+    for (const auto& i : i2) {
+      idcs_new.push_back(idcs[start + i]);
+    }
+    idcs = idcs_new;
+  }
+  assert_dbg(idcs.size() == n_ep, krims::ExcInternalError());
+  return idcs;
+}
+
+}  // namespace linalgwrap

--- a/src/linalgwrap/CMakeLists.txt
+++ b/src/linalgwrap/CMakeLists.txt
@@ -32,6 +32,7 @@ set(LINALGWRAP_SOURCES
 	Base/Solvers/LinearSolverBaseKeys.cc
 	Base/Solvers/SolverStateBase.cc
 	Arpack/ArpackEigensolver.cc
+	Lapack/detail/lapack.cc
 	LinearSolver.cc
 	EigensystemSolver.cc
 	rescue.cc

--- a/src/linalgwrap/Lapack.hh
+++ b/src/linalgwrap/Lapack.hh
@@ -1,0 +1,21 @@
+//
+// Copyright (C) 2017 by the linalgwrap authors
+//
+// This file is part of linalgwrap.
+//
+// linalgwrap is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// linalgwrap is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with linalgwrap. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+#include "Lapack/LapackEigensolver.hh"

--- a/src/linalgwrap/Lapack/LapackEigensolver.hh
+++ b/src/linalgwrap/Lapack/LapackEigensolver.hh
@@ -1,0 +1,235 @@
+//
+// Copyright (C) 2017 by the linalgwrap authors
+//
+// This file is part of linalgwrap.
+//
+// linalgwrap is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// linalgwrap is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with linalgwrap. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+#ifdef LINALGWRAP_HAVE_LAPACK
+#include "detail/lapack.hh"
+#include "linalgwrap/Base/Solvers.hh"
+#include "linalgwrap/Exceptions.hh"
+#include <krims/Algorithm.hh>
+
+namespace linalgwrap {
+
+DefSolverException2(ExcLapackInfo, std::string, function, int, info,
+                    << "Lapack function " << function << " returned with info value "
+                    << info
+                    << ". Check Arpack documentation for the meaning of this value.");
+
+template <typename Eigenproblem>
+struct LapackEigensolverState : public EigensolverStateBase<Eigenproblem> {
+  typedef EigensolverStateBase<Eigenproblem> base_type;
+  typedef typename base_type::eproblem_type eproblem_type;
+  typedef typename base_type::scalar_type scalar_type;
+  typedef typename base_type::size_type size_type;
+
+  /** Setup the initial state from an eigenproblem to solve */
+  LapackEigensolverState(const eproblem_type problem) : base_type(std::move(problem)) {}
+};
+
+/** Class which contains all GenMap keys which are understood
+ *  by the LapackEigensolver update_control_params as static string
+ *  members.
+ *  See their doc strings for the types required. */
+struct LapackEigensolverKeys : public EigensolverBaseKeys {};
+
+/** \brief Lapack eigensolver class
+ *
+ * ## Control parameters and their default values
+ *   - which:    Which eigenvalues to target. Default: "SR";
+ *     allowed values:
+ *       - "SR"   Smallest real value
+ *       - "LR"   Largest real magnitude
+ *       - "SM"   Smallest magnitude
+ *       - "LM"   Largest magnitude
+ *       - "SI"   Smallest imaginary
+ *                (only for complex scalar types)
+ *       - "LI"   Largest imaginary
+ *                (only for complex scalar types)
+ *
+ * \note Currently only double precision scalar types can be used
+ * \note Currently the tolerance parameter has no effect on the
+ *       solver.
+ * \note This solver implicitly solves for all eigenpairs
+ *       and then truncates the result down to the actually requested
+ *       number.
+ *
+ * \tparam Eigenproblem  The eigenproblem to solve.
+ * \tparam State         The state type of the solver.
+ */
+template <typename Eigenproblem, typename State = LapackEigensolverState<Eigenproblem>>
+class LapackEigensolver : public EigensolverBase<State> {
+  static_assert(std::is_same<typename Eigenproblem::scalar_type, double>::value,
+                "LapackEigensolver is only implemented for double precision scalar type");
+
+  static_assert(Eigenproblem::hermitian,
+                "Can only solve Hermitian eigenproblems at the moment.");
+
+ public:
+  //@{
+  /** Forwarded types */
+  typedef EigensolverBase<State> base_type;
+  typedef typename base_type::state_type state_type;
+  typedef typename base_type::size_type size_type;
+  typedef typename base_type::scalar_type scalar_type;
+  typedef typename base_type::real_type real_type;
+  typedef typename base_type::evalue_type evalue_type;
+  typedef typename base_type::evector_type evector_type;
+  typedef typename base_type::esoln_type esoln_type;
+  typedef typename base_type::stored_matrix_type stored_matrix_type;
+  //@}
+
+  /** \name Constructor */
+  //@{
+  /** Construct an eigensolver with the default parameters */
+  LapackEigensolver() {}
+
+  /** Construct an eigensolver setting the parameters from the map */
+  LapackEigensolver(const krims::GenMap& map) : LapackEigensolver() {
+    base_type::update_control_params(map);
+  }
+  //@}
+
+  /** Implementation of the IterativeSolver method */
+  virtual void solve_state(state_type& state) const override;
+
+ private:
+  /** Check that the control parameters are in a valid state */
+  void assert_valid_control_params(state_type& state) const;
+
+  /** Order the eigenvalues and copy the appropriate ones (selected by which)
+   * into the solution data structure */
+  void copy_to_solution(size_type n_ep, const std::vector<evalue_type>& eval,
+                        const std::vector<typename evector_type::scalar_type>& evec,
+                        esoln_type& soln) const;
+};
+
+template <typename Eigenproblem, typename State>
+void LapackEigensolver<Eigenproblem, State>::assert_valid_control_params(
+      state_type& state) const {
+  // TODO I do not like this, since some checks could be performed
+  // before the call of solve ... separate this?
+  //
+  // Some stuff is more general and affects multiple solver classes
+  // this is not reflected here
+  //
+  // Here is code duplication with ArmadilloEigensolver
+
+  const Eigenproblem& problem = state.eigenproblem();
+
+  //
+  // which
+  //
+  const std::string& which = base_type::which;
+  /*
+  const bool complexok =
+        krims::IsComplexNumber<evalue_type>::value && (which == "SI" || which == "LI");
+        */
+  solver_assert(
+        which == "SM" || which == "LM" || which == "LR" || which == "SR" /*|| complexok*/,
+        state, ExcInvalidSolverParametersEncountered(
+                     "The value " + which + " for which is not allowed in an "
+                                            "Lapack solver call (only SR, LR, SM and LM "
+                                            "are accepted for problems with real "
+                                            "eigenvalues and LI and SI are additionally "
+                                            "accepted for complex eigenvalues."));
+
+  //
+  // A and Diag
+  //
+  // note: We compare memory addresses
+  solver_assert(&problem.A() == &problem.Diag(), state,
+                ExcInvalidSolverParametersEncountered("The matrices A and Diag need "
+                                                      "to be the same objects."));
+}
+
+template <typename Eigenproblem, typename State>
+void LapackEigensolver<Eigenproblem, State>::solve_state(state_type& state) const {
+  assert_dbg(!state.is_failed(), krims::ExcInvalidState("Cannot solve a failed state"));
+
+  esoln_type& soln = state.eigensolution();
+  const Eigenproblem& problem = state.eigenproblem();
+
+  assert_valid_control_params(state);
+  static_assert(std::is_same<typename Eigenproblem::scalar_type, double>::value,
+                "LapackEigensolver is only implemented for double precision scalar type");
+  static_assert(Eigenproblem::hermitian,
+                "Can only solve Hermitian eigenproblems at the moment.");
+
+  // Run hermitian generalised or normal hermitian
+  // eigenproblem for double precision:
+  int info;
+  std::vector<double> evals;
+  std::vector<double> evecs;
+  detail::LapackPackedMatrix<double> Ap{problem.A()};
+
+  if (Eigenproblem::generalised) {
+    detail::LapackPackedMatrix<double> Bp{problem.B()};
+    auto Bp_chol = detail::run_dspgv(std::move(Ap), std::move(Bp), evals, evecs, info);
+    // TODO Bp_chol contains the choleski decomposition of B!
+    //      Expose this result!
+    (void)Bp_chol;
+  } else {
+    detail::run_dspev(std::move(Ap), evals, evecs, info);
+  }
+  solver_assert(info == 0, state, ExcLapackInfo("dspgv", info));
+
+  // Check that we get the solution in the expected format.
+  assert_dbg(evals.size() * evals.size() == evecs.size(), krims::ExcInternalError());
+  assert_dbg(evals.size() >= problem.n_ep(), krims::ExcInternalError());
+
+  // Copy the results over to solution data structure:
+  copy_to_solution(problem.n_ep(), evals, evecs, soln);
+}
+
+template <typename Eigenproblem, typename State>
+void LapackEigensolver<Eigenproblem, State>::copy_to_solution(
+      size_type n_ep, const std::vector<evalue_type>& eval,
+      const std::vector<typename evector_type::scalar_type>& evec,
+      esoln_type& soln) const {
+
+  // Lapack always sorts its eigenvalues canonically
+  //    TODO check for complex eigenvalues!
+  const bool sorted_canonically = true;
+
+  // (Sorted) indices of eigenvalues to keep
+  const std::vector<size_t> idcs = select_eigenvalues(
+        std::begin(eval), std::end(eval), base_type::which, n_ep, sorted_canonically);
+
+  // Reserve space to copy the values in
+  soln.evalues().clear();
+  soln.evectors().clear();
+  soln.evalues().reserve(n_ep);
+  soln.evectors().reserve(n_ep);
+
+  // The size of the eigenproblem:
+  const size_t N = eval.size();
+  for (const auto& idx : idcs) {
+    // The iterator range describing the current vector
+    // This works, since Fortran arrays are column-major,
+    // i.e. column-by-column, vector-by-vector
+    auto vbegin = std::begin(evec) + idx * N;
+    auto vend = std::begin(evec) + (idx + 1) * N;
+
+    soln.evectors().emplace_back(vbegin, vend);
+    soln.evalues().push_back(eval[idx]);
+  }
+}
+
+}  // namespace linalgwrap
+#endif  // LINALGWRAP_HAVE_LAPACK

--- a/src/linalgwrap/Lapack/detail/LapackPackedMatrix.hh
+++ b/src/linalgwrap/Lapack/detail/LapackPackedMatrix.hh
@@ -1,0 +1,94 @@
+//
+// Copyright (C) 2017 by the linalgwrap authors
+//
+// This file is part of linalgwrap.
+//
+// linalgwrap is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// linalgwrap is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with linalgwrap. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+#ifdef LINALGWRAP_HAVE_LAPACK
+#include "linalgwrap/StoredMatrix_i.hh"
+#include <vector>
+
+namespace linalgwrap {
+namespace detail {
+
+/** Data structure to represent a packed matrix
+ *
+ * From the point of view of Fortran this *always* represents
+ * a lower triangle of the symmetric matrix provided
+ * upon construction.
+ */
+template <typename Scalar>
+struct LapackPackedMatrix {
+  typedef Scalar scalar_type;
+
+  //! The number of rows and the number of columns
+  size_t n;
+
+  //! The linearised packed matrix elements.
+  std::vector<Scalar> elements;
+
+  /** Default construct */
+  LapackPackedMatrix() = default;
+
+  /** Construct from a usual symmetric linalgwrap matrix by copying the
+   *  values in
+   */
+  LapackPackedMatrix(const Matrix_i<Scalar>& m);
+
+  /** Export to a linalgwrap matrix making it a full symmetric matrix
+   *  again (i.e. both triangles will be set by this function) */
+  void copy_symmetric_to(StoredMatrix_i<Scalar>& m);
+};
+
+//
+// --------------------------------------------------
+//
+
+template <typename Scalar>
+LapackPackedMatrix<Scalar>::LapackPackedMatrix(const Matrix_i<Scalar>& m)
+      : n(m.n_rows()), elements(n * (n + 1) / 2) {
+  assert_dbg(m.is_symmetric(100 * linalgwrap::Constants<scalar_type>::default_tolerance),
+             linalgwrap::ExcMatrixNotSymmetric());
+
+  // Note: Since Fortran is column-major, but all our matrices are row-major,
+  // we need to use the lower triangle-order when the upper triangle is requested
+  // and vice versa.
+
+  // TODO Use extract_block
+  for (size_t i = 0, c = 0; i < n; ++i) {
+    for (size_t j = i; j < n; ++j, ++c) {
+      elements[c] = m(i, j);
+    }
+  }
+}
+
+template <typename Scalar>
+void LapackPackedMatrix<Scalar>::copy_symmetric_to(StoredMatrix_i<Scalar>& m) {
+  assert_size(m.n_rows(), n);
+  assert_size(m.n_cols(), n);
+
+  // TODO Improve cache misses
+  for (size_t i = 0, c = 0; i < n; ++i) {
+    for (size_t j = i; j < n; ++j, ++c) {
+      m(i, j) = m(j, i) = elements[c];
+    }
+  }
+}
+
+}  // namespace detail
+}  // namespace linalgwrap
+#endif  // LINALGWRAP_HAVE_LAPACK

--- a/src/linalgwrap/Lapack/detail/lapack.cc
+++ b/src/linalgwrap/Lapack/detail/lapack.cc
@@ -1,0 +1,77 @@
+//
+// Copyright (C) 2017 by the linalgwrap authors
+//
+// This file is part of linalgwrap.
+//
+// linalgwrap is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// linalgwrap is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with linalgwrap. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifdef LINALGWRAP_HAVE_LAPACK
+#include "lapack.hh"
+
+namespace linalgwrap {
+namespace detail {
+
+//
+// dspgv: Real generalized symmetric-definite eigenproblem (A and B in packed storage)
+//
+extern "C" void dspgv_(int* itype, char* jobz, char* uplo, int* n, double* ap, double* bp,
+                       double* w, double* z, int* ldz, double* work, int* info);
+
+LapackPackedMatrix<double> run_dspgv(LapackPackedMatrix<double> Ap,
+                                     LapackPackedMatrix<double> Bp,
+                                     std::vector<double>& evals,
+                                     std::vector<double>& evecs, int& info) {
+  assert_size(Ap.n, Bp.n);
+  assert_size(Ap.elements.size(), Bp.elements.size());
+  assert_size(Ap.n * (Ap.n + 1) / 2, Ap.elements.size());
+  evecs.resize(Ap.n * Ap.n);
+  evals.resize(Ap.n);
+
+  int n = static_cast<int>(Ap.n);
+  std::vector<double> work(3 * Ap.n);  //< The work type
+  int itype = 1;                       //< Jobtype to do (here: A*v = \lambda*B*v
+  char jobz = 'V';                     //< Compute eigenvalues and eigenvectors
+  char uplo = 'L';                     //< Ap and Bp contain the lower triangles
+  dspgv_(&itype, &jobz, &uplo, &n, Ap.elements.data(), Bp.elements.data(), evals.data(),
+         evecs.data(), &n, work.data(), &info);
+
+  // After the dspgv run Bp actually contains the choleski factorisation of Bp, which
+  // might be of use for later.
+  return Bp;
+}
+
+//
+// dspev: Real non-general eigenproblem (A in packed storage)
+//
+extern "C" void dspev_(char* jobz, char* uplo, int* n, double* ap, double* w, double* z,
+                       int* ldz, double* work, int* info);
+
+void run_dspev(LapackPackedMatrix<double> Ap, std::vector<double>& evals,
+               std::vector<double>& evecs, int& info) {
+  assert_size(Ap.n * (Ap.n + 1) / 2, Ap.elements.size());
+  evecs.resize(Ap.n * Ap.n);
+  evals.resize(Ap.n);
+
+  int n = static_cast<int>(Ap.n);
+  std::vector<double> work(3 * Ap.n);  //< The work type
+  char jobz = 'V';                     //< Compute eigenvalues and eigenvectors
+  char uplo = 'L';                     //< Ap and Bp contain the lower triangles
+  dspev_(&jobz, &uplo, &n, Ap.elements.data(), evals.data(), evecs.data(), &n,
+         work.data(), &info);
+}
+
+}  // namespace detail
+}  // namespace linalgwrap
+#endif  // LINALGWRAP_HAVE_LAPACK

--- a/src/linalgwrap/Lapack/detail/lapack.hh
+++ b/src/linalgwrap/Lapack/detail/lapack.hh
@@ -1,0 +1,67 @@
+//
+// Copyright (C) 2017 by the linalgwrap authors
+//
+// This file is part of linalgwrap.
+//
+// linalgwrap is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// linalgwrap is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with linalgwrap. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+#ifdef LINALGWRAP_HAVE_LAPACK
+#include "LapackPackedMatrix.hh"
+
+namespace linalgwrap {
+namespace detail {
+
+/** Run the generalised Lapack eigensolver dspgv
+ *
+ * The Ap array is copied in and destroyed internally
+ * The Bp array is copied in as well
+ *
+ * \param Ap  A array in packed format (as generated from make_packed_lower)
+ * \param Bp  B array in packed format (as generated from make_packed_lower)
+ * \param evecs   The eigenvectors (in Fortran format, i.e. column-major)
+ *                (will be resized by the function)
+ * \param evals   The eigenvalues ordered by value
+ *                (will be resized by the function)
+ * \param info   The info parameter returned by Lapack
+ *
+ * \returns  The Choleski factorisation of B in lower-triangle packed format.
+ */
+LapackPackedMatrix<double> run_dspgv(LapackPackedMatrix<double> Ap,
+                                     LapackPackedMatrix<double> Bp,
+                                     std::vector<double>& evals,
+                                     std::vector<double>& evecs, int& info);
+
+/** Run the Lapack eigensolver dspev
+ *
+ * The Ap array is copied in and destroyed internally
+ *
+ * \param Ap  A array in packed format (as generated from make_packed_lower)
+ * \param evecs   The eigenvectors (in Fortran format, i.e. column-major)
+ *                (will be resized by the function)
+ * \param evals   The eigenvalues ordered by value
+ *                (will be resized by the function)
+ * \param info   The info parameter returned by Lapack
+ */
+void run_dspev(LapackPackedMatrix<double> Ap, std::vector<double>& evals,
+               std::vector<double>& evecs, int& info);
+
+// TODO What about the many million other interesting lapack solvers ...
+//
+// E.g. dsygst instead of dspgst
+
+}  // namespace detail
+}  // namespace linalgwrap
+#endif  // LINALGWRAP_HAVE_LAPACK

--- a/src/linalgwrap/Matrix_i.hh
+++ b/src/linalgwrap/Matrix_i.hh
@@ -136,14 +136,16 @@ class Matrix_i : public Indexable_i<Scalar> {
    * Loops over all elements and check whether the difference
    * between m(i,j) and m(j,i) is less than the tolerance given
    * */
-  bool is_symmetric(real_type tolerance = Constants<real_type>::default_tolerance) const;
+  bool is_symmetric(real_type tolerance = 10 *
+                                          Constants<real_type>::default_tolerance) const;
 
   /** \brief Check whether the matrix is Hermitian
    *
    * Loops over all elements and check whether the difference
    * between conj(m(i,j)) and m(j,i) is less than the tolerance given
    * */
-  bool is_hermitian(real_type tolerance = Constants<real_type>::default_tolerance) const;
+  bool is_hermitian(real_type tolerance = 10 *
+                                          Constants<real_type>::default_tolerance) const;
 
   /** \brief Return the properties satisfied by this matrix by means of its internal
    * structure.

--- a/src/linalgwrap/detail/MultiVectorBase.hh
+++ b/src/linalgwrap/detail/MultiVectorBase.hh
@@ -316,6 +316,10 @@ template <typename InnerVector>
 template <typename... Args>
 void MultiVectorReadonly<InnerVector>::emplace_back(Args&&... args) {
   auto ptr = std::make_shared<vector_type>(std::forward<Args>(args)...);
+  if (m_vs.size() == 0) {
+    // Initial m_n_elem size cache
+    m_n_elem = ptr->size();
+  }
   assert_size(ptr->size(), m_n_elem);
   m_vs.push_back(std::move(vector_rcptr_type{ptr}));
   assert_valid_state();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ set(LINALGWRAP_TESTS_SOURCES
 	# Eigensolver
 	ArpackEigensolverTests.cc
 	ArmadilloEigensolverTests.cc
+	LapackEigensolverTests.cc
 	eigensystemTests.cc
 
 	# linear solver

--- a/tests/LapackEigensolverTests.cc
+++ b/tests/LapackEigensolverTests.cc
@@ -1,0 +1,91 @@
+//
+// Copyright (C) 2016-17 by the linalgwrap authors
+//
+// This file is part of linalgwrap.
+//
+// linalgwrap is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// linalgwrap is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with linalgwrap. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#ifdef LINALGWRAP_HAVE_LAPACK
+#include "eigensolver_tests.hh"
+#include <linalgwrap/Lapack/LapackEigensolver.hh>
+
+namespace linalgwrap {
+namespace tests {
+using namespace rc;
+
+/** Traits class needed for the tests */
+struct LapackEigensolverTraits {
+  template <typename Eigenproblem>
+  using Solver = LapackEigensolver<Eigenproblem>;
+};
+
+TEST_CASE("LapackEigensolver", "[LapackEigensolver]") {
+  using namespace eigensolver_tests;
+  typedef ArmadilloMatrix<double> matrix_type;
+
+  SECTION("Test LapackPackedMatrix") {
+    matrix_type M{{1, 2, 3}, {2, 4, 5}, {3, 5, 6}};
+
+    detail::LapackPackedMatrix<double> pack(M);
+
+    CHECK(pack.elements.size() == 6);
+    CHECK(pack.elements[0] == 1);
+    CHECK(pack.elements[1] == 2);
+    CHECK(pack.elements[2] == 3);
+    CHECK(pack.elements[3] == 4);
+    CHECK(pack.elements[4] == 5);
+    CHECK(pack.elements[5] == 6);
+
+    matrix_type Mback(3, 3);
+    pack.copy_symmetric_to(Mback);
+    CHECK(Mback == M);
+  }
+
+  SECTION("Real hermitian normal problems") {
+    typedef EigensolverTestProblem<matrix_type, /* Hermitian= */ true> tprob_type;
+    TestProblemRunner<tprob_type, DefaultSolveFunctor<LapackEigensolverTraits>> tr;
+    tr.run_normal();
+  }  // real hermitian normal problems
+
+  SECTION("Real hermitian generalised problems") {
+    typedef EigensolverTestProblem<matrix_type, /* Hermitian= */ true> tprob_type;
+    TestProblemRunner<tprob_type, DefaultSolveFunctor<LapackEigensolverTraits>> tr;
+
+    // Run all problems as generalised problems.
+    tr.solve_functor().force_generalised = true;
+    tr.run_all();
+  }  // real hermitian generalised problems
+
+  //  TODO Not yet there
+  //  SECTION("Real non-hermitian normal problems") {
+  //    typedef EigensolverTestProblem<matrix_type, /* Hermitian= */ false> tprob_type;
+  //    TestProblemRunner<tprob_type, DefaultSolveFunctor<LapackEigensolverTraits>> tr;
+  //    tr.run_normal();
+  //  }  // real hermitian normal problems
+  //
+  //  SECTION("Real non-hermitian generalised problems") {
+  //    typedef EigensolverTestProblem<matrix_type, /* Hermitian= */ false> tprob_type;
+  //    TestProblemRunner<tprob_type, DefaultSolveFunctor<LapackEigensolverTraits>> tr;
+  //
+  //    // Run all problems as generalised problems.
+  //    tr.solve_functor().force_generalised = true;
+  //    tr.run_all();
+  //  }  // real hermitian generalised problems
+
+}  // LapackEigensolver
+}  // tests
+}  // linalgwrap
+
+#endif  // LINALGWRAP_HAVE_LAPACK


### PR DESCRIPTION
Since armadillo fails to properly handle generalised real symmetric eigenproblems, this pull request adds a way to directly solve such eigenproblems using a call to LAPACK.